### PR TITLE
SENTIFLOW-23 | Add templates for issues & Code reviews

### DIFF
--- a/.github/ISSUE_TEMPLATE/issues.yml
+++ b/.github/ISSUE_TEMPLATE/issues.yml
@@ -1,0 +1,73 @@
+name: Request
+description: Use this to request a new feature or task
+title: "[Request] "
+labels:
+  - needs-triage
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 🏷️ Label Guide
+
+        Choose the most appropriate label in the next field:
+
+        - `enhancement`: A new feature  
+        - `bug`: Something broken  
+        - `needs-triage`: Needs review  
+        - `backlog`: Not urgent  
+        - `blocked`: Waiting on something  
+        - `design-needed`: Needs design input  
+        - `documentation`: Needs docs  
+        - `high-priority`: Important and urgent  
+        - `low-priority`: Not important or urgent  
+        - `frontend`: UI or client-related  
+        - `backend`: API, DB, or server-side
+
+  - type: dropdown
+    id: label_choice
+    attributes:
+      label: Suggested Label
+      description: Select one (won't be auto-applied)
+      options:
+        - enhancement
+        - bug
+        - needs-triage
+        - backlog
+        - blocked
+        - design-needed
+        - documentation
+        - high-priority
+        - low-priority
+        - frontend
+        - backend
+    validations:
+      required: true
+
+  - type: textarea
+    id: request
+    attributes:
+      label: Request
+      description: Describe what the goal or change is
+      placeholder: What we want...
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any helpful implementation or context notes
+      placeholder: Details that pertain to completing the objective
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Write this in user-story form
+      placeholder: As a ___, I want ___ so that ___.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,24 @@
+---
+name: Bugfix PR
+about: Use this template for bugfixin'
+---
+
+## What Was Broken
+
+(Describe the bug in plain terms. What was happening, and why was it a problem?)
+
+## The Fix
+
+(Explain your solution. How did you approach the fix, and why this method?)
+
+## Testing Instructions
+
+1. Open page ___
+2. Trigger ___
+3. Confirm ___ is resolved
+
+## Checklist
+
+- [ ] Bug has a linked issue or context (e.g., “Fixes #123”)
+- [ ] I verified this fixes the bug in all relevant browsers/devices
+- [ ] I’ve labeled this PR (e.g., `bug`, `frontend`, `backend`)

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,32 @@
+---
+name: Standard Pull Request
+about: Use this template for features
+---
+
+## Summary
+
+(Brief description of what this PR does.)
+
+## Related Issue(s)
+
+Link to relevant issues:
+- Closes #123
+
+## Changes
+
+List of high-level changes:
+- Added ___
+- Removed ___
+- Updated ___
+
+## Testing Instructions
+
+How to test this PR:
+1. Go to ___
+2. Click ___
+3. Expect ___
+
+## Checklist
+
+- [ ] I've linked the appropriate issue(s)
+- [ ] I've labeled this PR with relevant tags (bug, enhancement, etc.)


### PR DESCRIPTION
## Summary

This PR adds templates to the project

## Related Issue(s)

Link to relevant issues:
- Closes #23 

## Changes

List of high-level changes:
- Added `.github/PULL_REQUEST_TEMPLATE`
- Added `.github/ISSUE_TEMPLATE`

## Testing Instructions

How to test this PR:

🤷 - can't really test it until it lives in main/master

## Checklist

- [x] I've linked the appropriate issue(s)
- [x] I've labeled this PR with relevant tags (bug, enhancement, etc.)

## Notes

Templates for Issues & Code reviews (like this one) allow the developer to quickly fill out the necessary details. 

In the words of UX pro Steve Krug, "Don't Make Me Think"

More deets: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

